### PR TITLE
Correcting env variables

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -3,6 +3,8 @@ import json
 import os
 import boto3
 
+DYNAMODB_TABLE = os.environ['DYNAMODB_TABLE']
+
 dynamodb = boto3.resource('dynamodb')
 
 def lambda_handler(event, context):
@@ -15,7 +17,7 @@ def lambda_handler(event, context):
         print(message)
 
         # Write message to DynamoDB
-        table = dynamodb.Table('Message')
+        table = dynamodb.Table(DYNAMODB_TABLE)
 
         response = table.put_item(
             Item={


### PR DESCRIPTION
2 changes proposed:

declare env variable missed, table name was hard coded, which deviates from what is shown in the solution video.

1) In the video (lab video 2, timestamp 6:03) this env variable was declared, but the source code as at 12 Jan 2023 missed this key line. (lines 6)

2) at line 19, the source code hard coded the 'Messages' table name. This conflicts with the video where the environment variable passes the table name. 

HTH other ACG learners.